### PR TITLE
fix(opencode): use env vars for API keys, default Gemini + normalize

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,14 +1,15 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "autoupdate": false,
-  "model": "arcee-ai/trinity-mini:free",
+  "model": "google/gemini-2.5-flash-lite",
+  "default_agent": "normalize",
   "provider": {
     "openrouter": {
       "models": {
         "arcee-ai/trinity-mini:free": {}
       },
       "options": {
-        "apiKey": "{file:.secrets/openrouter-api-key}",
+        "apiKey": "{env:OPENROUTER_API_KEY}",
         "baseURL": "https://openrouter.ai/api/v1"
       }
     },
@@ -17,7 +18,7 @@
         "gemini-2.5-flash-lite": {}
       },
       "options": {
-        "apiKey": "{file:.secrets/gemini-api-key}"
+        "apiKey": "{env:GEMINI_API_KEY}"
       }
     }
   },


### PR DESCRIPTION
Fixes CI error: `bad file reference: .secrets/openrouter-api-key` (file does not exist in runner).

**Changes in `opencode.json`:**
- **API keys**: `{file:.secrets/...}` → `{env:GEMINI_API_KEY}` and `{env:OPENROUTER_API_KEY}` so the ingest workflow can use GitHub Secrets via env (no `.secrets/` on runner).
- **Default model**: `google/gemini-2.5-flash-lite` (was OpenRouter trinity-mini).
- **default_agent**: `normalize` so opencode uses Gemini and the normalize agent by default.

Workflow already passes `GEMINI_API_KEY` and `OPENROUTER_API_KEY`; no workflow changes needed.

Made with [Cursor](https://cursor.com)