### PR TITLE
feat: refactor pipeline into 4 separate processes

### DIFF
--- a/.github/workflows/ingest-emails.yml
+++ b/.github/workflows/ingest-emails.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   ingest:
@@ -27,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install -g @googleworkspace/cli opencode-ai
+          npm install -g @googleworkspace/cli
           uv sync
 
       - name: Restore GWS credentials
@@ -46,5 +45,4 @@ jobs:
         env:
           GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE: /tmp/gws/credentials.json
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
         run: uv run python scripts/ingest_emails.py

--- a/.github/workflows/normalize-requests.yml
+++ b/.github/workflows/normalize-requests.yml
@@ -1,0 +1,54 @@
+name: Normalize Requests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Ingest branch to normalize (e.g. ingest/20260307-120000)'
+        required: true
+        type: string
+      run_folder:
+        description: 'Timestamp folder inside raw_emails/ (e.g. 20260307-120000)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  normalize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: |
+          npm install -g opencode-ai
+          uv sync
+
+      - name: Configure git
+        run: |
+          git config user.name "requests-buddy[bot]"
+          git config user.email "requests-buddy[bot]@users.noreply.github.com"
+
+      - name: Run normalize
+        env:
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          uv run python scripts/normalize_requests.py
+          --run-folder "${{ inputs.run_folder }}"
+          --branch "${{ inputs.branch }}"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Requests Buddy
 
-Automated pipeline that ingests email requests from Gmail, deduplicates them using AI, and syncs everything to Google NotebookLM — orchestrated by GitHub Actions.
+Automated pipeline that ingests email requests from Gmail, normalizes them with AI, deduplicates, and syncs everything to Google NotebookLM — orchestrated by GitHub Actions.
 
 ## What It Does
 
-1. **Email Ingestion** (hourly) — Fetches unread Gmail messages, converts them to structured Markdown files under `requests/`, and commits them to `main`.
-2. **Deduplication** (daily) — Compares new requests against existing ones using an LLM via OpenRouter. Merges duplicates into unified documents and opens a PR for review.
-3. **NotebookLM Sync** (on push) — Keeps a NotebookLM notebook in sync with the `requests/` folder — adding new sources, removing stale ones, and updating a metadata source with the last sync timestamp.
+Four processes run as separate GitHub Actions workflows:
+
+1. **Ingest Emails** (hourly) — Fetches unread Gmail messages and saves them as raw Markdown to `raw_emails/<timestamp>/`. Each run gets its own timestamped folder on a dedicated branch (`ingest/<ts>`), then triggers Process 2.
+2. **Normalize Requests** (triggered by Process 1) — Runs the AI normalize agent on the raw emails from an ingest branch, writes structured request documents to `requests/`, creates a PR, and auto-merges it to `main`.
+3. **Sync NotebookLM** (on push to main) — Keeps a NotebookLM notebook in sync with the `requests/` folder — adding new sources, removing stale ones, and updating a metadata source with the last sync timestamp.
+4. **Deduplicate** (daily) — Scans requests for semantic duplicates using AI, merges them, and opens a PR for human review (not auto-merged).
 
 ## How to Start
 
@@ -49,17 +52,30 @@ Go to the [Actions tab](https://github.com/raziele/requests-buddy/actions) and t
 
 ### 4. Done
 
-All three processes now run unattended on their schedules. Email ingestion runs every hour, deduplication runs daily at 06:00 UTC, and NotebookLM sync triggers whenever new files are pushed to `requests/`.
+All four processes now run unattended. Email ingestion runs every hour and automatically triggers normalization. Deduplication runs daily at 06:00 UTC and opens PRs for human review. NotebookLM sync triggers whenever normalized requests are merged to `main`.
 
 ## Running scripts locally
 
 Use `uv run` so scripts use the project environment:
 
 ```bash
+# Process 1: ingest emails (creates branch, triggers Process 2)
 uv run python scripts/ingest_emails.py
-uv run python scripts/deduplicate.py
+
+# Process 2: normalize a specific ingest run (with PR + merge)
+uv run python scripts/normalize_requests.py --run-folder 20260307-120000 --branch ingest/20260307-120000
+
+# Process 2: normalize specific folders (no PR)
+uv run python scripts/normalize_requests.py raw_emails/20260307-120000/some-folder
+
+# Process 3: sync to NotebookLM
 uv run python scripts/sync_notebooklm.py
-uv run python scripts/test_normalize.py raw_emails/some-folder
+
+# Process 4: deduplicate
+uv run python scripts/deduplicate.py
+
+# Test normalize on a folder
+uv run python scripts/test_normalize.py raw_emails/20260307-120000/some-folder
 ```
 
 Scripts load `.env` from the repo root; set `GOOGLE_GENERATIVE_AI_API_KEY` (or `GEMINI_API_KEY`) there for opencode normalize.
@@ -96,17 +112,20 @@ If you need to rotate a secret (e.g., new OpenRouter API key), update the file i
 
 ```
 .github/workflows/
-  ingest-emails.yml       # Hourly cron
-  deduplicate.yml         # Daily cron
-  sync-notebooklm.yml     # Trigger on push to requests/
+  ingest-emails.yml         # Process 1: hourly cron — emails → raw_emails/
+  normalize-requests.yml    # Process 2: dispatched by P1 — raw_emails/ → requests/ → merge
+  sync-notebooklm.yml      # Process 3: on push to main — requests/ → NotebookLM
+  deduplicate.yml           # Process 4: daily cron — detect & merge duplicates → open PR
 scripts/
-  setup.sh                # Interactive first-time setup
-  upload-secrets.sh       # Upload local credentials to GitHub secrets
-  ingest_emails.py        # Process 1: email ingestion
-  deduplicate.py          # Process 2: AI deduplication
-  sync_notebooklm.py      # Process 3: NotebookLM sync
-  reset.py                # Reset: clean notebook + delete requests
-  utils.py                # Shared helpers
-requests/                  # Ingested request Markdown files
-logs/                      # NotebookLM sync logs and source manifest
+  setup.sh                  # Interactive first-time setup
+  upload-secrets.sh          # Upload local credentials to GitHub secrets
+  ingest_emails.py           # Process 1: fetch Gmail → raw_emails/<ts>/<slug>/
+  normalize_requests.py      # Process 2: normalize raw emails → requests/
+  deduplicate.py             # Process 4: AI deduplication
+  sync_notebooklm.py         # Process 3: NotebookLM sync
+  reset.py                   # Reset: clean notebook + delete requests
+  utils.py                   # Shared helpers
+raw_emails/                   # Raw ingested emails (timestamped run folders)
+requests/                     # Normalized request Markdown files
+logs/                         # NotebookLM sync logs and source manifest
 ```

--- a/scripts/deduplicate.py
+++ b/scripts/deduplicate.py
@@ -1,29 +1,31 @@
 #!/usr/bin/env python3
-"""Process 2: Detect semantically duplicate requests and create a merge PR."""
+"""Process 4: Detect semantically duplicate requests and create a merge PR."""
 
 import hashlib
 import json
 import os
 import sys
+import tempfile
 from datetime import datetime, timezone
 from glob import glob
 
 sys.path.insert(0, os.path.dirname(__file__))
 
 from utils import (
+    GEMINI_MODEL,
     git,
     git_commit_and_push,
     gh_pr_create,
     log,
     opencode_run,
     parse_frontmatter,
-    render_frontmatter,
 )
 
 
 REQUESTS_DIR = "requests"
 MARKER_FILE = "logs/last-dedup-marker"
 PROMPTS_DIR = "prompts"
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 
 def get_new_files(marker_path: str) -> tuple[list[str], list[str]]:
@@ -104,7 +106,21 @@ def detect_duplicates(new_summaries: list[dict], existing_summaries: list[dict])
         existing_requests=json.dumps(existing_summaries, indent=2),
     )
 
-    response = opencode_run(prompt)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", prefix="dedup-detect-", delete=False,
+    ) as tmp:
+        tmp.write(prompt)
+        prompt_file = tmp.name
+
+    try:
+        response = opencode_run(
+            "Analyze the attached file and return the JSON as instructed.",
+            files=[prompt_file],
+            model=GEMINI_MODEL,
+            cwd=PROJECT_ROOT,
+        )
+    finally:
+        os.unlink(prompt_file)
 
     text = response.strip()
     if text.startswith("```"):
@@ -135,7 +151,21 @@ def merge_group(group_files: list[str]) -> tuple[str, str]:
 
     prompt = load_prompt("merge-duplicates", documents=documents_block)
 
-    merged = opencode_run(prompt)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", prefix="dedup-merge-", delete=False,
+    ) as tmp:
+        tmp.write(prompt)
+        prompt_file = tmp.name
+
+    try:
+        merged = opencode_run(
+            "Merge the duplicate documents as instructed in the attached file.",
+            files=[prompt_file],
+            model=GEMINI_MODEL,
+            cwd=PROJECT_ROOT,
+        )
+    finally:
+        os.unlink(prompt_file)
 
     # Strip markdown code fences if present
     text = merged.strip()

--- a/scripts/ingest_emails.py
+++ b/scripts/ingest_emails.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
-"""Step 1: Fetch unread Gmail messages and save raw emails to raw_emails/.
+"""Process 1: Fetch unread Gmail messages and save raw emails to raw_emails/.
 
-Each email gets its own folder:
-    raw_emails/<slug>/
-        email.md          # frontmatter + raw body
-        attachment1.pdf    # any attachments
-        attachment2.png
+Each ingestion run creates a timestamped folder:
+    raw_emails/<timestamp>/
+        <slug>/
+            email.md          # frontmatter + raw body
+            attachment1.pdf   # any attachments
 """
 
 import base64
 import json
 import os
+import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -19,8 +20,6 @@ from datetime import datetime, timezone
 
 from utils import (
     gws,
-    gh_pr_create,
-    gh_pr_merge,
     git_commit_and_push,
     git_create_branch,
     log,
@@ -197,8 +196,8 @@ def build_raw_markdown(headers: dict, body: str, attachments: list[str]) -> str:
     return render_frontmatter(meta, "\n".join(sections))
 
 
-def process_message(msg_stub: dict, label_id: str) -> tuple[str, list[str], dict[str, str]] | None:
-    """Fetch a single message and save it to raw_emails/<slug>/.
+def process_message(msg_stub: dict, label_id: str, run_dir: str) -> tuple[str, list[str], dict[str, str]] | None:
+    """Fetch a single message and save it to run_dir/<slug>/.
 
     Returns (slug, created_files, headers) or None on failure.
     """
@@ -217,7 +216,7 @@ def process_message(msg_stub: dict, label_id: str) -> tuple[str, list[str], dict
     body = decode_body(msg.get("payload", {}))
 
     slug = make_slug(date, subject)
-    folder = os.path.join(RAW_DIR, slug)
+    folder = os.path.join(run_dir, slug)
     os.makedirs(folder, exist_ok=True)
 
     attachment_filenames = extract_attachments(msg, folder)
@@ -238,7 +237,7 @@ def process_message(msg_stub: dict, label_id: str) -> tuple[str, list[str], dict
     return slug, created_files, headers
 
 
-def build_commit_message(headers: dict, slug: str, num_attachments: int) -> str:
+def build_commit_message(headers: dict, run_ts: str, slug: str, num_attachments: int) -> str:
     subject = headers.get("subject", "no-subject")
     sender = headers.get("from", "unknown")
     date = headers.get("date", "unknown")
@@ -252,24 +251,21 @@ def build_commit_message(headers: dict, slug: str, num_attachments: int) -> str:
         f"From: {sender}\n"
         f"Date: {date}\n"
         f"Message-ID: {msg_id}\n"
-        f"File: raw_emails/{slug}/"
+        f"File: raw_emails/{run_ts}/{slug}/"
     )
 
 
-def build_pr_body(ingested: list[tuple[str, dict]], normalized_count: int = 0) -> str:
-    lines = [f"Ingested **{len(ingested)}** email(s) into `raw_emails/`.\n"]
-    for slug, headers in ingested:
-        subject = headers.get("subject", "no-subject")
-        sender = headers.get("from", "unknown")
-        lines.append(f"- **{subject}** — from {sender} → `raw_emails/{slug}/`")
-    if normalized_count:
-        lines.append(f"\nNormalized into **{normalized_count}** request document(s) in `requests/`.")
-    return "\n".join(lines)
+def trigger_normalize(branch: str, run_folder: str):
+    """Trigger the normalize-requests workflow via GitHub CLI."""
+    log(f"Triggering normalize workflow for branch={branch} run_folder={run_folder}")
+    subprocess.run(
+        ["gh", "workflow", "run", "normalize-requests.yml",
+         "-f", f"branch={branch}", "-f", f"run_folder={run_folder}"],
+        check=True,
+    )
 
 
 def main():
-    os.makedirs(RAW_DIR, exist_ok=True)
-
     log("Ensuring processed label exists...")
     label_id = ensure_processed_label()
 
@@ -283,6 +279,9 @@ def main():
     log(f"Found {len(messages)} unread email(s).")
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    run_dir = os.path.join(RAW_DIR, ts)
+    os.makedirs(run_dir, exist_ok=True)
+
     branch = f"ingest/{ts}"
     git_create_branch(branch)
     log(f"Created branch {branch}")
@@ -290,46 +289,23 @@ def main():
     ingested: list[tuple[str, dict]] = []
 
     for msg_stub in messages:
-        result = process_message(msg_stub, label_id)
+        result = process_message(msg_stub, label_id, run_dir)
         if not result:
             continue
 
         slug, created_files, headers = result
         att_count = len(created_files) - 1
 
-        commit_msg = build_commit_message(headers, slug, att_count)
+        commit_msg = build_commit_message(headers, ts, slug, att_count)
         git_commit_and_push(created_files, commit_msg, branch=branch)
         ingested.append((slug, headers))
-        log(f"  Committed raw_emails/{slug}/")
+        log(f"  Committed raw_emails/{ts}/{slug}/")
 
     if not ingested:
         log("No emails were successfully processed.")
         return
 
-    from normalize_requests import process_folder as normalize_folder
-
-    normalized_files: list[str] = []
-    for slug, _headers in ingested:
-        folder = os.path.join(RAW_DIR, slug)
-        created = normalize_folder(folder)
-        normalized_files.extend(created)
-
-    if normalized_files:
-        git_commit_and_push(
-            normalized_files,
-            f"normalize: {len(normalized_files)} request document(s)",
-            branch=branch,
-        )
-        log(f"Committed {len(normalized_files)} normalized file(s)")
-
-    pr_title = f"ingest: {len(ingested)} new email(s) — {ts}"
-    pr_body = build_pr_body(ingested, len(normalized_files))
-    pr_url = gh_pr_create(pr_title, pr_body)
-    log(f"Created PR: {pr_url}")
-
-    gh_pr_merge(pr_url)
-    log(f"PR merged: {pr_url}")
-
+    trigger_normalize(branch, ts)
     log("Ingestion complete.")
 
 

--- a/scripts/normalize_requests.py
+++ b/scripts/normalize_requests.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
-"""Step 2: Normalize raw emails into structured request documents.
+"""Process 2: Normalize raw emails into structured request documents.
 
-Reads each folder in raw_emails/, sends the email + PDF attachments to
-the OpenRouter API with the normalize-request prompt, and writes the
+Reads raw email folders, sends the email + PDF attachments to the
+normalize agent (opencode/Gemini or OpenRouter), and writes the
 result to requests/.
 
+When invoked with --run-folder, operates on a specific ingest run,
+commits results, creates a PR, and auto-merges it to main.
+
 Usage:
-    uv run python scripts/normalize_requests.py                     # all pending
-    uv run python scripts/normalize_requests.py raw_emails/<slug>   # specific folder
+    uv run python scripts/normalize_requests.py --run-folder 20260307-120000
+    uv run python scripts/normalize_requests.py raw_emails/<ts>/<slug>   # specific folder
+    uv run python scripts/normalize_requests.py                          # all pending
 """
 
+import argparse
 import base64
 import json
 import mimetypes
@@ -26,6 +31,9 @@ load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
 
 from utils import (
     GEMINI_MODEL,
+    gh_pr_create,
+    gh_pr_merge,
+    git_commit_and_push,
     log,
     make_slug,
     opencode_run,
@@ -361,8 +369,28 @@ def _copy_attachments(raw_folder: str, md_path: str) -> list[str]:
     return copied
 
 
+def find_folders_in_run(run_folder: str) -> list[str]:
+    """Return all email folders inside a specific run directory (raw_emails/<ts>/)."""
+    run_dir = os.path.join(RAW_DIR, run_folder)
+    if not os.path.isdir(run_dir):
+        return []
+
+    folders = []
+    for name in sorted(os.listdir(run_dir)):
+        folder = os.path.join(run_dir, name)
+        if not os.path.isdir(folder):
+            continue
+        if not os.path.exists(os.path.join(folder, "email.md")):
+            continue
+        folders.append(folder)
+    return folders
+
+
 def find_pending_folders() -> list[str]:
-    """Return raw_emails/ folders that don't yet have a normalized request."""
+    """Return raw_emails/ folders that don't yet have a normalized request.
+
+    Handles both flat (raw_emails/<slug>/) and nested (raw_emails/<ts>/<slug>/) layouts.
+    """
     if not os.path.isdir(RAW_DIR):
         return []
 
@@ -371,16 +399,39 @@ def find_pending_folders() -> list[str]:
         folder = os.path.join(RAW_DIR, name)
         if not os.path.isdir(folder):
             continue
-        if not os.path.exists(os.path.join(folder, "email.md")):
+        if os.path.exists(os.path.join(folder, "email.md")):
+            pending.append(folder)
             continue
-        pending.append(folder)
+        for sub in sorted(os.listdir(folder)):
+            subfolder = os.path.join(folder, sub)
+            if os.path.isdir(subfolder) and os.path.exists(os.path.join(subfolder, "email.md")):
+                pending.append(subfolder)
 
     return pending
 
 
+def _build_pr_body(run_folder: str, created_files: list[str]) -> str:
+    lines = [
+        f"Normalized **{len(created_files)}** request document(s) "
+        f"from ingest run `{run_folder}`.\n",
+    ]
+    for f in created_files:
+        if f.endswith(".md"):
+            lines.append(f"- `{f}`")
+    return "\n".join(lines)
+
+
 def main():
-    if len(sys.argv) > 1:
-        folders = sys.argv[1:]
+    parser = argparse.ArgumentParser(description="Normalize raw emails into requests")
+    parser.add_argument("folders", nargs="*", help="Specific raw_emails/<ts>/<slug> folders")
+    parser.add_argument("--run-folder", help="Timestamp of the ingest run to normalize")
+    parser.add_argument("--branch", help="Branch name (for PR creation)")
+    args = parser.parse_args()
+
+    if args.run_folder:
+        folders = find_folders_in_run(args.run_folder)
+    elif args.folders:
+        folders = args.folders
     else:
         folders = find_pending_folders()
 
@@ -390,12 +441,32 @@ def main():
 
     log(f"Found {len(folders)} folder(s) to normalize.")
 
-    total_created = []
+    total_created: list[str] = []
     for folder in folders:
         created = process_folder(folder)
         total_created.extend(created)
 
     log(f"Done. Created {len(total_created)} request document(s).")
+
+    if not total_created:
+        log("Nothing to commit.")
+        return
+
+    if args.run_folder and args.branch:
+        git_commit_and_push(
+            total_created,
+            f"normalize: {len(total_created)} request document(s) from run {args.run_folder}",
+            branch=args.branch,
+        )
+        log(f"Committed {len(total_created)} normalized file(s)")
+
+        pr_title = f"ingest+normalize: {len(total_created)} request(s) — {args.run_folder}"
+        pr_body = _build_pr_body(args.run_folder, total_created)
+        pr_url = gh_pr_create(pr_title, pr_body)
+        log(f"Created PR: {pr_url}")
+
+        gh_pr_merge(pr_url)
+        log(f"PR merged: {pr_url}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Splits the monolithic ingest-and-normalize flow into four distinct processes:

| Process | Trigger | Result |
|--------|---------|--------|
| **1. Ingest** | Hourly / manual | Branch `ingest/<ts>` with `raw_emails/<ts>/<slug>/`, triggers P2 |
| **2. Normalize** | Dispatched by P1 | Normalize agent on raw emails → `requests/`, PR created and **auto-merged** to main |
| **3. Sync NotebookLM** | Push to main (`requests/**`) | Unchanged — syncs `requests/` to NotebookLM |
| **4. Deduplicate** | Daily / manual | Branch + **open PR only** (no auto-merge); fixed `opencode_run` `files=` usage |

## Changes

- **ingest_emails.py**: Remove normalize/PR steps; write to `raw_emails/<timestamp>/<slug>/`; trigger `normalize-requests` workflow after push.
- **ingest-emails.yml**: No opencode/Gemini; ingestion-only.
- **normalize_requests.py**: `--run-folder` + `--branch`; commit, create PR, auto-merge to main.
- **normalize-requests.yml**: New workflow (workflow_dispatch with `branch`, `run_folder`).
- **deduplicate.py**: Fix `opencode_run()` calls (temp file for `files=`).
- **README.md**: Document 4-process architecture and local usage.

Made with [Cursor](https://cursor.com)