### PR TITLE
Trigger normalize on push to ingest/*; single push after ingest

### DIFF
--- a/.github/workflows/normalize-requests.yml
+++ b/.github/workflows/normalize-requests.yml
@@ -1,6 +1,11 @@
 name: Normalize Requests
 
 on:
+  push:
+    branches:
+      - 'ingest/**'
+    paths:
+      - 'raw_emails/**'
   workflow_dispatch:
     inputs:
       branch:
@@ -22,8 +27,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive run parameters
+        id: params
+        run: |
+          if [ -n "${{ inputs.run_folder }}" ]; then
+            echo "run_folder=${{ inputs.run_folder }}" >> "$GITHUB_OUTPUT"
+            echo "branch=${{ inputs.branch }}" >> "$GITHUB_OUTPUT"
+          else
+            BRANCH="${{ github.ref_name }}"
+            RUN_FOLDER="${BRANCH#ingest/}"
+            echo "run_folder=${RUN_FOLDER}" >> "$GITHUB_OUTPUT"
+            echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/setup-node@v4
         with:
@@ -50,5 +68,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >
           uv run python scripts/normalize_requests.py
-          --run-folder "${{ inputs.run_folder }}"
-          --branch "${{ inputs.branch }}"
+          --run-folder "${{ steps.params.outputs.run_folder }}"
+          --branch "${{ steps.params.outputs.branch }}"

--- a/scripts/ingest_emails.py
+++ b/scripts/ingest_emails.py
@@ -11,7 +11,6 @@ Each ingestion run creates a timestamped folder:
 import base64
 import json
 import os
-import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -20,8 +19,9 @@ from datetime import datetime, timezone
 
 from utils import (
     gws,
-    git_commit_and_push,
+    git_commit,
     git_create_branch,
+    git_push,
     log,
     make_slug,
     render_frontmatter,
@@ -255,15 +255,6 @@ def build_commit_message(headers: dict, run_ts: str, slug: str, num_attachments:
     )
 
 
-def trigger_normalize(branch: str, run_folder: str):
-    """Trigger the normalize-requests workflow via GitHub CLI."""
-    log(f"Triggering normalize workflow for branch={branch} run_folder={run_folder}")
-    subprocess.run(
-        ["gh", "workflow", "run", "normalize-requests.yml",
-         "-f", f"branch={branch}", "-f", f"run_folder={run_folder}"],
-        check=True,
-    )
-
 
 def main():
     log("Ensuring processed label exists...")
@@ -297,7 +288,7 @@ def main():
         att_count = len(created_files) - 1
 
         commit_msg = build_commit_message(headers, ts, slug, att_count)
-        git_commit_and_push(created_files, commit_msg, branch=branch)
+        git_commit(created_files, commit_msg)
         ingested.append((slug, headers))
         log(f"  Committed raw_emails/{ts}/{slug}/")
 
@@ -305,8 +296,8 @@ def main():
         log("No emails were successfully processed.")
         return
 
-    trigger_normalize(branch, ts)
-    log("Ingestion complete.")
+    git_push(branch)
+    log("Ingestion complete — normalize will run automatically on push.")
 
 
 if __name__ == "__main__":

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -234,14 +234,24 @@ def git_create_branch(name: str):
     git("checkout", "-b", name)
 
 
-def git_commit_and_push(files: list[str], message: str, branch: str = "main"):
-    """Stage files, commit with message, and push to remote."""
+def git_commit(files: list[str], message: str):
+    """Stage files and commit (without pushing)."""
     if not files:
         return
     for f in files:
         git("add", f)
     git("commit", "-m", message)
+
+
+def git_push(branch: str = "main"):
+    """Push current branch to origin."""
     git("push", "origin", branch)
+
+
+def git_commit_and_push(files: list[str], message: str, branch: str = "main"):
+    """Stage files, commit with message, and push to remote."""
+    git_commit(files, message)
+    git_push(branch)
 
 
 def git_has_changes() -> bool:


### PR DESCRIPTION
## Summary
- **Normalize workflow** runs on push to `ingest/**` when `raw_emails/**` changes (fixes HTTP 403 from `gh workflow run`).
- **Ingest** commits each email separately but pushes once at the end so normalize is triggered exactly once.

## Changes
- `.github/workflows/normalize-requests.yml`: add `push` trigger; derive `run_folder`/`branch` from ref when not workflow_dispatch.
- `scripts/ingest_emails.py`: use `git_commit` in loop, `git_push(branch)` once after loop; remove `trigger_normalize`.
- `scripts/utils.py`: add `git_commit` and `git_push`; `git_commit_and_push` delegates to both.

Made with [Cursor](https://cursor.com)