### PR TITLE
fix: use PAT for ingest push so normalize workflow triggers

### DIFF
--- a/.github/workflows/ingest-emails.yml
+++ b/.github/workflows/ingest-emails.yml
@@ -12,9 +12,10 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     steps:
+      # PAT required: pushes with GITHUB_TOKEN do not trigger other workflows.
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -44,5 +45,5 @@ jobs:
       - name: Run ingestion
         env:
           GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE: /tmp/gws/credentials.json
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
         run: uv run python scripts/ingest_emails.py

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Your GCP OAuth app is in **Testing** mode. Only accounts listed as **Test users*
 
 Expected when the app is in testing mode. Click **Advanced** → **Go to &lt;app&gt; (unsafe)** to continue. Safe for personal use.
 
+### Ingest runs but Normalize never triggers
+
+Pushes made with the default `GITHUB_TOKEN` from a workflow **do not** trigger other workflows (GitHub prevents recursive runs). Add a [Personal Access Token](https://github.com/settings/tokens) with `repo` scope as the repository secret **REPO_ACCESS_TOKEN**. The ingest workflow uses it for checkout and push so that the push triggers the Normalize workflow. If the secret is missing, ingest still runs but normalize must be triggered manually (e.g. workflow_dispatch).
+
 ## Updating Credentials
 
 If you need to rotate a secret (e.g., new OpenRouter API key), update the file in `.secrets/` and re-run:


### PR DESCRIPTION
Pushes made with `GITHUB_TOKEN` from a workflow do not trigger other workflows. Ingest now uses `REPO_ACCESS_TOKEN` (when set) for checkout and push so the push triggers the Normalize workflow.

- **Workflow:** `token` and `GH_TOKEN` use `secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN`
- **README:** New troubleshooting entry for "Ingest runs but Normalize never triggers" — add a PAT as `REPO_ACCESS_TOKEN`

Made with [Cursor](https://cursor.com)