### PR TITLE
fix: use arcee-ai/trinity-large-preview:free instead of openrouter/free

### DIFF
--- a/scripts/normalize_requests.py
+++ b/scripts/normalize_requests.py
@@ -2,7 +2,7 @@
 """Process 2: Normalize raw emails into structured request documents.
 
 Two-step pipeline, both via OpenRouter:
-  1. Extract text from PDF attachments (openrouter/free + pdf-text plugin)
+  1. Extract text from PDF attachments (arcee-ai/trinity-large-preview:free + pdf-text plugin)
   2. Normalize email + extracted text into structured JSON (opencode + arcee-ai)
 
 When invoked with --run-folder, operates on a specific ingest run,
@@ -118,7 +118,7 @@ def _extract_pdfs(folder: str) -> dict[str, str]:
 def normalize_email(folder: str) -> list[dict]:
     """Normalize raw email folder via two-step OpenRouter pipeline.
 
-    Step 1: Extract text from PDFs using openrouter/free + pdf-text plugin.
+    Step 1: Extract text from PDFs using arcee-ai/trinity-large-preview:free + pdf-text plugin.
     Step 2: Normalize email + extracted text using opencode + arcee-ai/trinity-mini.
     """
     fallback = [{"_fallback": True}]

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -67,7 +67,7 @@ def make_slug(date_str: str, subject: str, max_len: int = 80, include_date: bool
 # ---------------------------------------------------------------------------
 
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
-OPENROUTER_FREE_MODEL = "openrouter/free"
+OPENROUTER_FREE_MODEL = "arcee-ai/trinity-large-preview:free"
 
 
 def openrouter_chat(
@@ -134,7 +134,7 @@ def openrouter_chat(
 def openrouter_extract_pdf(pdf_path: str) -> str:
     """Extract text from a PDF file using OpenRouter's pdf-text plugin.
 
-    Sends the PDF as a base64 file part to the openrouter/free model and
+    Sends the PDF as a base64 file part to the arcee-ai/trinity-large-preview:free model and
     returns the extracted text content.
     """
     import base64


### PR DESCRIPTION
Switches OpenRouter calls from `openrouter/free` to `arcee-ai/trinity-large-preview:free` for PDF extraction and any other uses of `OPENROUTER_FREE_MODEL`.

Made with [Cursor](https://cursor.com)