### PR TITLE
fix: handle None organization in process_folder

### DIFF
--- a/scripts/normalize_requests.py
+++ b/scripts/normalize_requests.py
@@ -395,7 +395,7 @@ def process_folder(folder: str) -> list[str]:
             continue
 
         out_slug = generate_request_filename(req)
-        org_slug = make_slug("", req.get("organization", "unknown"), include_date=False)
+        org_slug = make_slug("", req.get("organization") or "unknown", include_date=False)
 
         out_dir = os.path.join(REQUESTS_DIR, org_slug, out_slug)
         n = 1


### PR DESCRIPTION
req.get("organization", "unknown") returns None when the key exists
with a null value; use `or "unknown"` to cover that case.

https://claude.ai/code/session_01XHXE8FzQqEc1AF9dzndS5b